### PR TITLE
Improve parsing of parentheses and "Deputy"

### DIFF
--- a/popit_resolver/fixtures/test_inputs/names.test
+++ b/popit_resolver/fixtures/test_inputs/names.test
@@ -1189,7 +1189,7 @@
     ], 
     [
         "The Leader Of The Opposition (DA)", 
-        "org.mysociety.za/person/422"
+        "org.mysociety.za/person/436"
     ], 
     [
         "Mr A Watson", 
@@ -1541,7 +1541,7 @@
     ], 
     [
         "Minister for Agriculture, Forestry and Fisheries", 
-        "org.mysociety.za/person/485"
+        "org.mysociety.za/person/46"
     ], 
     [
         "Minister for Co-operative Governance and Traditional Affairs", 
@@ -1565,7 +1565,7 @@
     ], 
     [
         "Minister for Justice and Constitutional Development", 
-        "org.mysociety.za/person/297"
+        "org.mysociety.za/person/332"
     ], 
     [
         "Minister for Provincial and Local Government", 
@@ -1689,7 +1689,7 @@
     ], 
     [
         "Minister of Mineral Resources", 
-        "org.mysociety.za/person/140"
+        null
     ], 
     [
         "Minister of Minerals and Energy", 
@@ -1782,5 +1782,45 @@
     [
         "Minister Trade and Industry", 
         "org.mysociety.za/person/208"
+    ],
+    [
+        "M Johnson", 
+        "org.mysociety.za/person/231"
+    ], 
+    [
+        "A Steyn",
+        "org.mysociety.za/person/475"
+    ],
+    [
+        "R Cebekhulu",
+        "org.mysociety.za/person/514"
+    ],
+    [
+        "N Twala",
+        "org.mysociety.za/person/54"
+    ],
+    [
+        "M Pilusa-Mosoane",
+        "org.mysociety.za/person/78"
+    ],
+    [
+        "The HOUSE CHAIRPERSON (Mr C T Frolick)",
+        "org.mysociety.za/person/26"
+    ],
+    [
+        "Mr C T Frolick",
+        "org.mysociety.za/person/26"
+    ],
+    [
+        "The HOUSE CHAIRPERSON",
+        "org.mysociety.za/person/515"
+    ],
+    [
+        "Mnr P J GROENEWALD",
+        "org.mysociety.za/person/486"
+    ],
+    [
+        "Mnr P J GROENEWALD (VF Plus)",
+        "org.mysociety.za/person/486"
     ]
 ]

--- a/popit_resolver/resolve.py
+++ b/popit_resolver/resolve.py
@@ -56,32 +56,55 @@ class ResolvePopitName (object):
                 .models(EntityName)
                 )
 
-            if len(results):
-                result = person = results[0]
-                # print >> sys.stderr, "SCORE %s" % str( result.score )
+            # ElasticSearch may treat the date closeness as more important than the presence of
+            # words like Deputy (oops) so we do an additional filter here
+            if not re.search('Deputy', name):
+                results = [r for r in results if not re.search('Deputy', r.object.name)]
 
+            if len(results):
+
+                result = person = results[0]
                 obj = result.object
+
+                # print >> sys.stderr, "SCORE %s" % str( result.score )
 
                 if not obj:
                     print >> sys.stderr, "Unexpected error: are you reusing main Elasticsearch index for tests?"
                     return None
 
                 return obj.person
-            else:
-                return None
-        
-        person = _get_person(name) or _get_person( self._strip_honorific(name) )
+
+        (name_sans_paren, paren) = self._get_name_and_paren(name)
+        person = (
+               _get_person( paren ) # favour this, as it might override
+            or _get_person( name ) 
+            or _get_person( name_sans_paren ) 
+            or _get_person( self._strip_honorific(name) )
+            or _get_person( self._strip_honorific(name_sans_paren) )
+            )
         if person:
             self.person_cache[name] = person
             return person
         return None
 
     def _strip_honorific(self, name):
+        if not name:
+            return None
         (stripped, changed) = re.subn( name_stopwords, '', name )
         if changed:
             return stripped
         return None
 
+    def _get_name_and_paren(self, name):
+        s = re.match(r'((?:\w|\s)+) \(((?:\w|\s)+)\)', name)
+        if s:
+            (pname, paren) = s.groups()
+            if len(paren.split()) >= 3:
+                # if parens with at least three words
+                return (pname, paren)
+            else:
+                return (pname, None)
+        return (None, None)
 
 class SetupEntities (object):
 


### PR DESCRIPTION
a) improve resolution for cases as per
https://github.com/mysociety/za-hansard/issues/25

```
The HOUSE CHAIRPERSON (Mr C T Frolick)  # temporary name
Mnr P J GROENEWALD (VF Plus)            # party name inc. spaces
```

To avoid mis-parsing we only check parens if there are 3 or more
space-separated tokens.  We check these first (as they may be overriding
house chairperson for that date, for example).

b) improve resolution of records such as "Deputy Minister for X"

ElasticSearch results seem to be happy to ignore the extraneous word
"Deputy", and though the extra word should lower the score, the closeness
of the date range may be (I'm guessing here?) increasing the score
in some cases.  So, if the search term doesn't include "Deputy", we filter the
word out from the results list too.
